### PR TITLE
State cache

### DIFF
--- a/src/main/File.java
+++ b/src/main/File.java
@@ -1,6 +1,7 @@
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URI;
 import java.nio.file.Path;
 import java.security.MessageDigest;
@@ -19,17 +20,11 @@ public final class File extends java.io.File implements Mutable {
     private static final long serialVersionUID = 1L;
 
     /**
-     * The modified time of the file
-     */
-    private final long modified;
-
-    /**
      * Creates a reference to a file specified by a URI
      * @param uri the file's URI
      */
     public File(URI uri) {
         super(uri);
-        this.modified = lastModified();
     }
 
     /**
@@ -38,7 +33,6 @@ public final class File extends java.io.File implements Mutable {
      */
     public File(String pathname) {
         super(pathname);
-        this.modified = lastModified();
     }
 
     /**
@@ -78,11 +72,11 @@ public final class File extends java.io.File implements Mutable {
         }
     }
 
-    public boolean modified() {
-        return modified == 0L || modified != lastModified();
-    }
-
     @Override public boolean equals(Object other) {
         return !(other instanceof File file) || super.equals(other);
+    }
+
+    public Serializable currentState() {
+        return lastModified();
     }
 }

--- a/src/main/Fileset.java
+++ b/src/main/Fileset.java
@@ -1,4 +1,5 @@
 import java.io.IOException;
+import java.io.Serializable;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -104,14 +105,16 @@ public final class Fileset implements Mutable, Iterable<File> {
         if (!new File(path).exists()) {
             return null;
         }
+        return new Fileset(findFiles(path, pattern).collect(Collectors.toCollection(TreeSet::new)), base, pattern);
+    }
+
+    private static Stream<File> findFiles(Path path, String pattern) {
         PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + pattern);
         try {
-            TreeSet<File> matches = Files.walk(path)
+            return Files.walk(path)
                 .filter(p -> matcher.matches(path.relativize(p)))
                 .map(File::new)
-                .filter(File::isFile)
-                .collect(Collectors.toCollection(TreeSet::new));
-            return new Fileset(matches, base, pattern);
+                .filter(File::isFile);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -149,11 +152,6 @@ public final class Fileset implements Mutable, Iterable<File> {
         return Objects.nonNull(root) ? Stream.of(new File(root)) : stream();
     }
 
-    public boolean modified() {
-        return Objects.nonNull(pattern) && !Objects.equals(this, find(root, pattern))
-                || files.stream().anyMatch(File::modified);
-    }
-
     /**
      * Gets a file from this fileset
      * @param path the relative path of the file
@@ -182,5 +180,9 @@ public final class Fileset implements Mutable, Iterable<File> {
         return !(obj instanceof Fileset other) || Objects.equals(files, other.files)
                 && Objects.equals(root, other.root)
                 && Objects.equals(pattern, other.pattern);
+    }
+
+    public Serializable currentState() {
+        return Mutable.snapshots(Objects.nonNull(pattern) ? findFiles(Path.of(root), pattern) : files.stream());
     }
 }

--- a/src/main/Fileset.java
+++ b/src/main/Fileset.java
@@ -109,6 +109,9 @@ public final class Fileset implements Mutable, Iterable<File> {
     }
 
     private static Stream<File> findFiles(Path path, String pattern) {
+        if (!Files.exists(path)) {
+            return Stream.empty();
+        }
         PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + pattern);
         try {
             return Files.walk(path)

--- a/src/main/org/copalis/jam/cli/BuildController.java
+++ b/src/main/org/copalis/jam/cli/BuildController.java
@@ -244,12 +244,18 @@ public class BuildController<T> {
 
     private void printCacheContents() {
         print("Contents of cache file ").print(cacheFile).line();
-        memo.entries().forEach(e -> {
-                printResultStatus(e);
-                color(BOLD).printMethod(e.signature().name(), e.signature().params());
-                color(RESET).print(" = ").printValue(e.value());
-                line();
-            });
+        memo.entries((e, current) -> {
+            printResultStatus(e, current);
+            color(BOLD).printMethod(e.signature().name(), e.signature().params());
+            color(RESET).print(" = ").printValue(e.value());
+            line();
+        });
+//        memo.entries().forEach(e -> {
+//                printResultStatus(e);
+//                color(BOLD).printMethod(e.signature().name(), e.signature().params());
+//                color(RESET).print(" = ").printValue(e.value());
+//                line();
+//            });
     }
 
     private void printBuildTargets(Consumer<T> buildFn) {
@@ -273,7 +279,7 @@ public class BuildController<T> {
         if (!targets.isEmpty()) {
             color(ITALIC).print(t.getSimpleName() + " targets").line();
             for (Method m : targets) {
-                printResultStatus(memo.lookup(new Invocation(m)));
+                printResultStatus(memo.lookup(new Invocation(m)), false);
                 color(BOLD).print(m.getName()).color(RESET).print(" : ");
                 print(m.getReturnType().getSimpleName()).line();
                 visited.add(m.getName());
@@ -286,13 +292,13 @@ public class BuildController<T> {
         }
     }
 
-    private void printResultStatus(Result result) {
+    private void printResultStatus(Result result, boolean fresh) {
         if (Objects.isNull(result)) {
             print("         ");
-        } else if (result.modified()) {
-            color(CYAN).print("[stale]  ");
-        } else {
+        } else if (fresh) {
             color(GREEN).print("[fresh]  ");
+        } else {
+            color(CYAN).print("[stale]  ");
         }
         color(RESET);
     }

--- a/src/main/org/copalis/jam/cli/BuildController.java
+++ b/src/main/org/copalis/jam/cli/BuildController.java
@@ -23,7 +23,6 @@ import java.util.stream.Stream;
 import org.copalis.jam.memo.Invocation;
 import org.copalis.jam.memo.Memorizer;
 import org.copalis.jam.memo.Observer;
-import org.copalis.jam.memo.Result;
 
 /**
  * A build process command-line argument parser and controller.
@@ -204,7 +203,7 @@ public class BuildController<T> {
                     }
 
                 } finally {
-                    if (memo.entries().findAny().isPresent()) {
+                    if (memo.entries((e, p) -> {}) > 0) {
                         try (OutputStream out = new FileOutputStream(cacheFile)) {
                             memo.save(out);
                         }
@@ -245,17 +244,11 @@ public class BuildController<T> {
     private void printCacheContents() {
         print("Contents of cache file ").print(cacheFile).line();
         memo.entries((e, current) -> {
-            printResultStatus(e, current);
+            printResultStatus(Objects.nonNull(e) ? current : null);
             color(BOLD).printMethod(e.signature().name(), e.signature().params());
             color(RESET).print(" = ").printValue(e.value());
             line();
         });
-//        memo.entries().forEach(e -> {
-//                printResultStatus(e);
-//                color(BOLD).printMethod(e.signature().name(), e.signature().params());
-//                color(RESET).print(" = ").printValue(e.value());
-//                line();
-//            });
     }
 
     private void printBuildTargets(Consumer<T> buildFn) {
@@ -279,7 +272,7 @@ public class BuildController<T> {
         if (!targets.isEmpty()) {
             color(ITALIC).print(t.getSimpleName() + " targets").line();
             for (Method m : targets) {
-                printResultStatus(memo.lookup(new Invocation(m)), false);
+                printResultStatus(memo.status(new Invocation(m)));
                 color(BOLD).print(m.getName()).color(RESET).print(" : ");
                 print(m.getReturnType().getSimpleName()).line();
                 visited.add(m.getName());
@@ -292,10 +285,10 @@ public class BuildController<T> {
         }
     }
 
-    private void printResultStatus(Result result, boolean fresh) {
-        if (Objects.isNull(result)) {
+    private void printResultStatus(Boolean status) {
+        if (Objects.isNull(status)) {
             print("         ");
-        } else if (fresh) {
+        } else if (status) {
             color(GREEN).print("[fresh]  ");
         } else {
             color(CYAN).print("[stale]  ");
@@ -322,6 +315,10 @@ public class BuildController<T> {
                 System.err.println("\tat " + el);
                 if (last) break;
                 last = last || el.getClassName().equals(BuildController.class.getName());
+            }
+            if (Objects.nonNull(ex.getCause())) {
+                System.err.println("Caused by:");
+                printStackTrace(ex.getCause());
             }
         }
     }

--- a/src/main/org/copalis/jam/memo/Invocation.java
+++ b/src/main/org/copalis/jam/memo/Invocation.java
@@ -1,5 +1,6 @@
 package org.copalis.jam.memo;
 
+import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -7,6 +8,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * The signature of a method call
@@ -40,7 +42,7 @@ public record Invocation(String name, List<Object> params) implements Mutable {
         return params.stream().allMatch(Memorizer::objSerializable);
     }
 
-    public boolean modified() {
-        return params.stream().anyMatch(Mutable::hasChanged);
+    public Serializable currentState() {
+        return params.stream().map(Mutable::currently).collect(Collectors.toCollection(LinkedList::new));
     }
 }

--- a/src/main/org/copalis/jam/memo/Invocation.java
+++ b/src/main/org/copalis/jam/memo/Invocation.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -40,6 +41,10 @@ public record Invocation(String name, List<Object> params) implements Mutable {
 
     boolean serializable() {
         return params.stream().allMatch(Memorizer::objSerializable);
+    }
+
+    public boolean current(Map<Mutable, Serializable> states) {
+        return params.stream().allMatch(o -> !(o instanceof Mutable m) || Objects.equals(m.currentState(), states.get(m)));
     }
 
     public Serializable currentState() {

--- a/src/main/org/copalis/jam/memo/Invocation.java
+++ b/src/main/org/copalis/jam/memo/Invocation.java
@@ -43,6 +43,11 @@ public record Invocation(String name, List<Object> params) implements Mutable {
         return params.stream().allMatch(Memorizer::objSerializable);
     }
 
+    /**
+     * Indicates whether this object is up to date with mutable state
+     * @param states a map of mutable states
+     * @return true if this object is up to date
+     */
     public boolean current(Map<Mutable, Serializable> states) {
         return params.stream().allMatch(o -> !(o instanceof Mutable m) || Objects.equals(m.currentState(), states.get(m)));
     }

--- a/src/main/org/copalis/jam/memo/Memorizer.java
+++ b/src/main/org/copalis/jam/memo/Memorizer.java
@@ -10,6 +10,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -45,7 +47,7 @@ import java.util.stream.Stream;
  * The method handler performs <i>staleness checking</i> on cached method calls which return or depend on
  * references to mutable resources such as files.
  * To enable staleness checking, objects which reference resources must implement {@link Mutable}.
- * A resource reference object is <i>modified</i> if {@link Mutable#modified} is true.
+ * A resource reference object is <i>modified</i> if its {@link Mutable#currentState} value changes.
  *<p>
  * A cached method call is <i>stale</i> if any of these conditions are met:
  * <ul>
@@ -63,7 +65,8 @@ import java.util.stream.Stream;
 public class Memorizer {
 
     private final LinkedList<Set<Mutable>> dependencies = new LinkedList<>();
-    private Map<Invocation, Result> cache = new LinkedHashMap<>();
+    private final Map<Mutable, Serializable> states = new HashMap<>();
+    private final Map<Invocation, Result> results = new LinkedHashMap<>();
     private final Observer observer;
 
     /**
@@ -91,11 +94,14 @@ public class Memorizer {
      * @throws IOException if an IO exception occurs
      * @throws ClassNotFoundException if a serialized class cannot be found
      */
+    @SuppressWarnings("unchecked")
     public void load(InputStream in) throws IOException, ClassNotFoundException {
         try (ObjectInputStream obj = new ObjectInputStream(in)) {
-            @SuppressWarnings("unchecked")
-            List<Result> results = (List<Result>) obj.readObject();
-            results.forEach(result -> cache.put(result.signature(), result));
+            Map<Mutable, Serializable> loadedStates = (Map<Mutable, Serializable>) obj.readObject();
+            states.clear();
+            loadedStates.forEach((key, value) -> {if (!key.modifiedSince(value) ) states.put(key, value);});
+            results.clear();
+            ((List<Result>) obj.readObject()).forEach(result -> results.put(result.signature(), result));
         }
     }
 
@@ -108,7 +114,8 @@ public class Memorizer {
      */
     public void save(OutputStream out) throws IOException {
         try (ObjectOutputStream obj = new ObjectOutputStream(out)) {
-            obj.writeObject(cache.values().stream().filter(Result::serializable)
+            obj.writeObject(states);
+            obj.writeObject(results.values().stream().filter(Result::serializable)
                     .collect(Collectors.toList()));
         }
     }
@@ -118,7 +125,15 @@ public class Memorizer {
      * @return a stream of cached method results
      */
     public Stream<Result> entries() {
-        return cache.values().stream();
+        return results.values().stream();
+    }
+
+    /**
+     * Iterates over the cache contents
+     * @param fn a callback
+     */
+    public void entries(BiConsumer<Result, Boolean> fn) {
+        results.values().forEach(val -> fn.accept(val, states.containsKey(val)));
     }
 
     /**
@@ -127,14 +142,14 @@ public class Memorizer {
      * @return a Result or null
      */
     public Result lookup(Invocation invocation) {
-        return cache.get(invocation);
+        return results.get(invocation);
     }
 
     /**
      * Erases all method call results from the cache
      */
     public void forget() {
-        cache = new LinkedHashMap<>();
+        results.clear();
     }
 
     /**
@@ -154,16 +169,17 @@ public class Memorizer {
         Invocation signature = new Invocation(method, args);
 
         Observer.Status status = Observer.Status.COMPUTE;
-        if (cache.containsKey(signature)) {
-            Result result = cache.get(signature);
+        if (results.containsKey(signature)) {
+            Result result = results.get(signature);
+            Object value = result.value();
 
-            if (result.modified()) {
+            if (value instanceof Mutable && !states.containsKey(value)) {
                 status = Observer.Status.REFRESH;
-                cache.remove(signature);
+                results.remove(signature);
             } else {
                 observer.startMethod(Observer.Status.CURRENT, method, signature.params());
                 dependencies.peek().addAll(result.dependencies());
-                observer.endMethod(Observer.Status.CURRENT, method, signature.params(), result.value());
+                observer.endMethod(Observer.Status.CURRENT, method, signature.params(), value);
                 return result.value();
             }
         }
@@ -180,10 +196,16 @@ public class Memorizer {
             value = observer.endMethod(status, method, signature.params(),
                     InvocationHandler.invokeDefault(proxy, method, args));
             if (method.getReturnType() != Void.TYPE) {
-                cache.put(signature, new Result(signature, value, dependencies.peek()));
+                results.put(signature, new Result(signature, value, dependencies.peek()));
             }
             if (Mutable.class.isAssignableFrom(method.getReturnType())) {
-                dependencies.peek().add((Mutable) Objects.requireNonNullElse(value, Mutable.CHANGED));
+                if (Objects.isNull(value)) {
+                    dependencies.peek().add(Mutable.CHANGED);
+                } else {
+                    Mutable m = (Mutable) value;
+                    dependencies.peek().add(m);
+                    states.computeIfAbsent(m, Mutable::currentState);
+                }
             }
             return value;
         } finally {

--- a/src/main/org/copalis/jam/memo/Memorizer.java
+++ b/src/main/org/copalis/jam/memo/Memorizer.java
@@ -170,7 +170,7 @@ public class Memorizer {
             Result result = results.get(signature);
             Object value = result.value();
 
-            if (value instanceof Mutable && !result.current(states)) {
+            if (!result.current(states)) {
                 status = Observer.Status.REFRESH;
                 results.remove(signature);
             } else {

--- a/src/main/org/copalis/jam/memo/Memorizer.java
+++ b/src/main/org/copalis/jam/memo/Memorizer.java
@@ -99,7 +99,9 @@ public class Memorizer {
         try (ObjectInputStream obj = new ObjectInputStream(in)) {
             Map<Mutable, Serializable> loadedStates = (Map<Mutable, Serializable>) obj.readObject();
             states.clear();
-            loadedStates.forEach((key, value) -> {if (!key.modifiedSince(value) ) states.put(key, value);});
+            loadedStates.forEach((key, value) -> {
+                if (!key.modifiedSince(value)) states.put(key, value);
+            });
             results.clear();
             ((List<Result>) obj.readObject()).forEach(result -> results.put(result.signature(), result));
         }
@@ -133,7 +135,7 @@ public class Memorizer {
      * @param fn a callback
      */
     public void entries(BiConsumer<Result, Boolean> fn) {
-        results.values().forEach(val -> fn.accept(val, states.containsKey(val)));
+        results.values().forEach(res -> fn.accept(res, res.current(states)));
     }
 
     /**
@@ -173,7 +175,7 @@ public class Memorizer {
             Result result = results.get(signature);
             Object value = result.value();
 
-            if (value instanceof Mutable && !states.containsKey(value)) {
+            if (value instanceof Mutable && !result.current(states)) {
                 status = Observer.Status.REFRESH;
                 results.remove(signature);
             } else {

--- a/src/main/org/copalis/jam/memo/Memorizer.java
+++ b/src/main/org/copalis/jam/memo/Memorizer.java
@@ -10,8 +10,8 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -20,7 +20,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * A method memoizer that can also determine when methods need to be re-executed as a result of
@@ -65,7 +64,7 @@ import java.util.stream.Stream;
 public class Memorizer {
 
     private final LinkedList<Set<Mutable>> dependencies = new LinkedList<>();
-    private final Map<Mutable, Serializable> states = new HashMap<>();
+    private final Map<Mutable, Serializable> states = new IdentityHashMap<>();
     private final Map<Invocation, Result> results = new LinkedHashMap<>();
     private final Observer observer;
 
@@ -123,28 +122,23 @@ public class Memorizer {
     }
 
     /**
-     * Gets the cache contents
-     * @return a stream of cached method results
-     */
-    public Stream<Result> entries() {
-        return results.values().stream();
-    }
-
-    /**
      * Iterates over the cache contents
      * @param fn a callback
+     * @return the number of cache entries
      */
-    public void entries(BiConsumer<Result, Boolean> fn) {
+    public int entries(BiConsumer<Result, Boolean> fn) {
         results.values().forEach(res -> fn.accept(res, res.current(states)));
+        return results.values().size();
     }
 
     /**
-     * Looks up a cache entry
+     * Checks if there is a current cache entry for a method call
      * @param invocation the method call
-     * @return a Result or null
+     * @return True if there is a current cache entry, False if it is stale, or null if there is no entry
      */
-    public Result lookup(Invocation invocation) {
-        return results.get(invocation);
+    public Boolean status(Invocation invocation) {
+        Result result = results.get(invocation);
+        return Objects.isNull(result) ? null : result.current(states);
     }
 
     /**
@@ -152,6 +146,7 @@ public class Memorizer {
      */
     public void forget() {
         results.clear();
+        states.clear();
     }
 
     /**

--- a/src/main/org/copalis/jam/memo/Mutable.java
+++ b/src/main/org/copalis/jam/memo/Mutable.java
@@ -1,6 +1,11 @@
 package org.copalis.jam.memo;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A reference to one or more resources that might have been modified since the reference was created
@@ -10,22 +15,46 @@ import java.io.Serializable;
 public interface Mutable extends Serializable {
 
     /**
-     * A Mutable instance that always returns true from {@link #modified()}
+     * A Mutable instance that always returns true from {@link #modifiedSince(Serializable)}
      */
-    static final Mutable CHANGED = () -> true;
+    static final Mutable CHANGED = () -> new Serializable() {
+
+        private static final long serialVersionUID = 1L;
+        @Override public boolean equals(Object other) {
+            return false;
+        }
+    };
 
     /**
-     * Checks if the resource has been modified since this reference was created
-     * @return true if the resource has been modified
+     * Returns a serializable representation of the current state of the resources
+     * @return an object
      */
-    boolean modified();
+    Serializable currentState();
 
     /**
-     * Checks if an object is a reference to a resource that has been modified
-     * @param obj an object that might be modifiable
-     * @return true if the resource has been modified
+     * Compares current and previous state
+     * @param oldState a previous state returned by {@link #currentState()}
+     * @return true if the current state is different to the old one
      */
-    static boolean hasChanged(Object obj) {
-        return obj instanceof Mutable mut && mut.modified();
+    default boolean modifiedSince(Serializable oldState) {
+        return !Objects.equals(oldState, currentState());
+    }
+
+    /**
+     * Returns an object's current state
+     * @param obj the object
+     * @return the object's current state if it is mutable, otherwise null
+     */
+    static Serializable currently(Object obj) {
+        return obj instanceof Mutable mut ? mut.currentState() : null;
+    }
+
+    /**
+     * Returns a representation of the current state of a stream of resources
+     * @param values the stream of objects
+     * @return a map of objects to their current state
+     */
+    static Serializable snapshots(Stream<?> values) {
+        return values.collect(Collectors.toMap(Function.identity(), Mutable::currently, (a, b) -> a, HashMap::new));
     }
 }

--- a/src/main/org/copalis/jam/memo/Result.java
+++ b/src/main/org/copalis/jam/memo/Result.java
@@ -1,5 +1,8 @@
 package org.copalis.jam.memo;
 
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.Set;
 
 /**
@@ -12,7 +15,11 @@ public record Result(Invocation signature, Object value, Set<Mutable> dependenci
     boolean serializable() {
         return Memorizer.objSerializable(value) && signature.serializable();
     }
-    public boolean modified() {
-        return signature.modified() || Mutable.hasChanged(value) || dependencies.stream().anyMatch(Mutable::hasChanged);
+//    public boolean modified() {
+//        return signature.modified() || Mutable.hasChanged(value) || dependencies.stream().anyMatch(Mutable::hasChanged);
+//    }
+
+    public Serializable currentState() {
+        return new LinkedList<>(Arrays.asList(signature.currentState(), Mutable.currently(value), Mutable.snapshots(dependencies.stream())));
     }
 }

--- a/src/main/org/copalis/jam/memo/Result.java
+++ b/src/main/org/copalis/jam/memo/Result.java
@@ -17,10 +17,12 @@ public record Result(Invocation signature, Object value, Set<Mutable> dependenci
     boolean serializable() {
         return Memorizer.objSerializable(value) && signature.serializable();
     }
-//    public boolean modified() {
-//        return signature.modified() || Mutable.hasChanged(value) || dependencies.stream().anyMatch(Mutable::hasChanged);
-//    }
 
+    /**
+     * Indicates whether this result is up to date with mutable state
+     * @param states a map of mutable states
+     * @return true if this result is up to date
+     */
     public boolean current(Map<Mutable, Serializable> states) {
         if (!(value instanceof Mutable)) return true;
         if (!Objects.equals(value, states.get(value))) return false;

--- a/src/main/org/copalis/jam/memo/Result.java
+++ b/src/main/org/copalis/jam/memo/Result.java
@@ -24,9 +24,9 @@ public record Result(Invocation signature, Object value, Set<Mutable> dependenci
      * @return true if this result is up to date
      */
     public boolean current(Map<Mutable, Serializable> states) {
-        if (!(value instanceof Mutable)) return true;
-        if (!Objects.equals(value, states.get(value))) return false;
         if (!signature.current(states)) return false;
+        if (!(value instanceof Mutable m)) return true;
+        if (!Objects.equals(m.currentState(), states.get(value))) return false;
         for (Mutable dependency : dependencies) {
             if (!Objects.equals(dependency.currentState(), states.get(dependency))) return false;
         }

--- a/src/main/org/copalis/jam/memo/Result.java
+++ b/src/main/org/copalis/jam/memo/Result.java
@@ -3,6 +3,8 @@ package org.copalis.jam.memo;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.LinkedList;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -18,6 +20,16 @@ public record Result(Invocation signature, Object value, Set<Mutable> dependenci
 //    public boolean modified() {
 //        return signature.modified() || Mutable.hasChanged(value) || dependencies.stream().anyMatch(Mutable::hasChanged);
 //    }
+
+    public boolean current(Map<Mutable, Serializable> states) {
+        if (!(value instanceof Mutable)) return true;
+        if (!Objects.equals(value, states.get(value))) return false;
+        if (!signature.current(states)) return false;
+        for (Mutable dependency : dependencies) {
+            if (!Objects.equals(dependency.currentState(), states.get(dependency))) return false;
+        }
+        return true;
+    }
 
     public Serializable currentState() {
         return new LinkedList<>(Arrays.asList(signature.currentState(), Mutable.currently(value), Mutable.snapshots(dependencies.stream())));

--- a/src/test/FileTest.java
+++ b/src/test/FileTest.java
@@ -3,6 +3,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.net.URISyntaxException;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -11,15 +12,17 @@ import org.junit.jupiter.api.Test;
 class FileTest {
 
     File file;
+    Serializable fileState;
 
     @BeforeEach
     void test() throws URISyntaxException {
         file = new File(getClass().getClassLoader().getResource("file.txt").toURI());
+        fileState = file.currentState();
     }
 
     @Test
     public void testCurrent() {
-        assertFalse(file.modified());
+        assertFalse(file.modifiedSince(fileState));
     }
 
     @Test

--- a/src/test/org/copalis/jam/memo/MemorizerTest.java
+++ b/src/test/org/copalis/jam/memo/MemorizerTest.java
@@ -2,7 +2,6 @@ package org.copalis.jam.memo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Method;
 import java.util.LinkedList;
@@ -82,50 +81,50 @@ public class MemorizerTest {
         }
     }
 
-    @Test synchronized public void testMutableChange() {
-        List<String> called = new LinkedList<>();
-
-        Memorizer memo = new Memorizer(new Observer() {
-            public void startMethod(Observer.Status status, Method method, List<Object> params) {
-                if (status == Observer.Status.COMPUTE || status == Observer.Status.REFRESH) {
-                    called.add(method.getName());
-                }
-            }
-        });
-
-        boolean[] changed = new boolean[] {false};
-        mutable = () -> changed[0];
-
-        Mutables t = memo.instantiate(Mutables.class);
-        t.a();
-        assertEquals(List.of("a", "aa", "ab", "ac", "ad", "ae"), called);
-        assertTrue(memo.entries().noneMatch(Result::modified));
-
-        called.clear();
-        t.a();
-        assertEquals(List.of(), called);
-        assertTrue(memo.entries().noneMatch(Result::modified));
-
-        changed[0] = true;
-        assertTrue(memo.entries().anyMatch(Result::modified));
-
-        called.clear();
-        t.a();
-        assertEquals(List.of("a", "ab", "ad"), called);
-
-        mutable = null;
-        called.clear();
-        t.a();
-        assertEquals(List.of("a", "ab", "ad"), called);
-
-        mutable = () -> false;
-        called.clear();
-        t.a();
-        assertEquals(List.of("a", "ab", "ad"), called);
-
-        called.clear();
-        t.a();
-        assertEquals(List.of(), called);
-        assertTrue(memo.entries().noneMatch(Result::modified));
-    }
+//    @Test synchronized public void testMutableChange() {
+//        List<String> called = new LinkedList<>();
+//
+//        Memorizer memo = new Memorizer(new Observer() {
+//            public void startMethod(Observer.Status status, Method method, List<Object> params) {
+//                if (status == Observer.Status.COMPUTE || status == Observer.Status.REFRESH) {
+//                    called.add(method.getName());
+//                }
+//            }
+//        });
+//
+//        boolean[] changed = new boolean[] {false};
+//        mutable = () -> changed[0];
+//
+//        Mutables t = memo.instantiate(Mutables.class);
+//        t.a();
+//        assertEquals(List.of("a", "aa", "ab", "ac", "ad", "ae"), called);
+//        assertTrue(memo.entries().noneMatch(Result::modifiedSince));
+//
+//        called.clear();
+//        t.a();
+//        assertEquals(List.of(), called);
+//        assertTrue(memo.entries().noneMatch(Result::modifiedSince));
+//
+//        changed[0] = true;
+//        assertTrue(memo.entries().anyMatch(Result::modifiedSince));
+//
+//        called.clear();
+//        t.a();
+//        assertEquals(List.of("a", "ab", "ad"), called);
+//
+//        mutable = null;
+//        called.clear();
+//        t.a();
+//        assertEquals(List.of("a", "ab", "ad"), called);
+//
+//        mutable = () -> false;
+//        called.clear();
+//        t.a();
+//        assertEquals(List.of("a", "ab", "ad"), called);
+//
+//        called.clear();
+//        t.a();
+//        assertEquals(List.of(), called);
+//        assertTrue(memo.entries().noneMatch(Result::modifiedSince));
+//    }
 }

--- a/src/test/org/copalis/jam/memo/MemorizerTest.java
+++ b/src/test/org/copalis/jam/memo/MemorizerTest.java
@@ -81,32 +81,29 @@ public class MemorizerTest {
         }
     }
 
-//    @Test synchronized public void testMutableChange() {
-//        List<String> called = new LinkedList<>();
-//
-//        Memorizer memo = new Memorizer(new Observer() {
-//            public void startMethod(Observer.Status status, Method method, List<Object> params) {
-//                if (status == Observer.Status.COMPUTE || status == Observer.Status.REFRESH) {
-//                    called.add(method.getName());
-//                }
-//            }
-//        });
-//
-//        boolean[] changed = new boolean[] {false};
-//        mutable = () -> changed[0];
-//
-//        Mutables t = memo.instantiate(Mutables.class);
-//        t.a();
-//        assertEquals(List.of("a", "aa", "ab", "ac", "ad", "ae"), called);
-//        assertTrue(memo.entries().noneMatch(Result::modifiedSince));
-//
-//        called.clear();
-//        t.a();
-//        assertEquals(List.of(), called);
-//        assertTrue(memo.entries().noneMatch(Result::modifiedSince));
-//
+    @Test synchronized public void testMutableChange() {
+        List<String> called = new LinkedList<>();
+
+        Memorizer memo = new Memorizer(new Observer() {
+            public void startMethod(Observer.Status status, Method method, List<Object> params) {
+                if (status == Observer.Status.COMPUTE || status == Observer.Status.REFRESH) {
+                    called.add(method.getName());
+                }
+            }
+        });
+
+        boolean[] changed = new boolean[] {false};
+        mutable = () -> changed[0];
+
+        Mutables t = memo.instantiate(Mutables.class);
+        t.a();
+        assertEquals(List.of("a", "aa", "ab", "ac", "ad", "ae"), called);
+
+        called.clear();
+        t.a();
+        assertEquals(List.of(), called);
+
 //        changed[0] = true;
-//        assertTrue(memo.entries().anyMatch(Result::modifiedSince));
 //
 //        called.clear();
 //        t.a();
@@ -125,6 +122,5 @@ public class MemorizerTest {
 //        called.clear();
 //        t.a();
 //        assertEquals(List.of(), called);
-//        assertTrue(memo.entries().noneMatch(Result::modifiedSince));
-//    }
+    }
 }

--- a/src/test/org/copalis/jam/memo/MemorizerTest.java
+++ b/src/test/org/copalis/jam/memo/MemorizerTest.java
@@ -3,9 +3,15 @@ package org.copalis.jam.memo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
 
@@ -48,79 +54,85 @@ public class MemorizerTest {
         assertThrowsExactly(IllegalArgumentException.class, foo::foo);
     }
 
-    static Mutable mutable;
+    static final Map<String, String> states = new HashMap<String, String>();
 
-    interface Mutables {
-        default String a() {
-            aa();       // no prior dependencies or parameters
-            ab("foo");  // records a dependency
-            ac();       // no parameters, so can't be affected by ab's dependency
-            ad("foo");  // one parameter, so could be affected by ab's dependency
-            ae(() -> false);
-            return "Done";
-        }
-
-        default String aa() {
-            return "";
-        }
-
-        default Mutable ab(String foo) {
-            return mutable;
-        }
-
-        default String ac() {
-            return "";
-        }
-
-        default String ad(String foo) {
-            return "";
-        }
-
-        default String ae(Mutable m) {
-            return "";
+    record State(String key) implements Mutable {
+        public String currentState() {
+            return states.get(key);
         }
     }
 
-    @Test synchronized public void testMutableChange() {
-        List<String> called = new LinkedList<>();
+    interface Project {
+        default State get(String key) {
+            return new State(key);
+        }
 
-        Memorizer memo = new Memorizer(new Observer() {
+        default State put(String key, String value) {
+            states.put(key, value);
+            return get(key);
+        }
+
+        default String name() {
+            return "jam";
+        }
+
+        default State version() {
+            return get("project-version");
+        }
+
+        default String projectName(State version) {
+            return name() + '-' + version.currentState();
+        }
+
+        default State build() {
+            return put("project-name", projectName(version()));
+        }
+    }
+
+    Observer methodObserver(List<String> called) {
+        return new Observer() {
             public void startMethod(Observer.Status status, Method method, List<Object> params) {
                 if (status == Observer.Status.COMPUTE || status == Observer.Status.REFRESH) {
                     called.add(method.getName());
                 }
             }
-        });
+        };
+    }
 
-        boolean[] changed = new boolean[] {false};
-        mutable = () -> changed[0];
+    @Test synchronized public void testDependencies() throws IOException, ClassNotFoundException {
+        states.put("project-version", "1.0");
 
-        Mutables t = memo.instantiate(Mutables.class);
-        t.a();
-        assertEquals(List.of("a", "aa", "ab", "ac", "ad", "ae"), called);
+        List<String> called = new LinkedList<>();
+        Memorizer memo;
+
+        memo = new Memorizer(methodObserver(called));
 
         called.clear();
-        t.a();
+        assertEquals("jam-1.0", memo.instantiate(Project.class).build().currentState());
+        assertEquals(List.of("build", "version", "get", "projectName", "name", "put", "get"), called);
+
+        called.clear();
+        assertEquals("jam-1.0", memo.instantiate(Project.class).build().currentState());
         assertEquals(List.of(), called);
 
-//        changed[0] = true;
-//
-//        called.clear();
-//        t.a();
-//        assertEquals(List.of("a", "ab", "ad"), called);
-//
-//        mutable = null;
-//        called.clear();
-//        t.a();
-//        assertEquals(List.of("a", "ab", "ad"), called);
-//
-//        mutable = () -> false;
-//        called.clear();
-//        t.a();
-//        assertEquals(List.of("a", "ab", "ad"), called);
-//
-//        called.clear();
-//        t.a();
-//        assertEquals(List.of(), called);
+        ByteArrayOutputStream saved = new ByteArrayOutputStream();
+        memo.save(saved);
+
+        // load cache into a new memorizer
+        memo = new Memorizer(methodObserver(called));
+        memo.load(new ByteArrayInputStream(saved.toByteArray()));
+
+        called.clear();
+        assertEquals("jam-1.0", memo.instantiate(Project.class).build().currentState());
+        assertEquals(List.of(), called);
+
+        // modify state and load a new memorizer
+        states.put("project-version", "2.0");
+        memo = new Memorizer(methodObserver(called));
+        memo.load(new ByteArrayInputStream(saved.toByteArray()));
+
+        called.clear();
+        assertEquals("jam-2.0", memo.instantiate(Project.class).build().currentState());
+        assertEquals(List.of("build", "version", "get", "projectName", "put", "get"), called);
     }
 }


### PR DESCRIPTION
Moved the representation of mutable state out of the mutables themselves and into a map stored with the cache, so that stale results can be identified at load time